### PR TITLE
🧑‍🏭 GPU Resource Factories

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="Source\GameObjects\Types\GhostObject.cpp" />
     <ClCompile Include="Source\GameObjects\ObjectFactory.cpp" />
     <ClCompile Include="Source\Rendering\BufferManager.cpp" />
+    <ClCompile Include="Source\Tools\BufferVisualizer.cpp" />
     <ClCompile Include="Source\Tools\GpuMarkerVisualizer.cpp" />
     <ClCompile Include="Source\Tools\InputViewTool.cpp" />
     <ClCompile Include="Source\GameObjects\Types\LevelEditorCamera.cpp" />
@@ -195,6 +196,7 @@
     <ClInclude Include="Headers\Tools\AudioParameters.h" />
     <ClInclude Include="Headers\Rendering\ModelLoading\ModelAnimation.h" />
     <ClInclude Include="Headers\Tools\BloomSettingsUI.h" />
+    <ClInclude Include="Headers\Tools\BufferVisualizer.h" />
     <ClInclude Include="Headers\Tools\GpuMarkerVisualizer.h" />
     <ClInclude Include="Headers\Tools\GridSettingsUI.h" />
     <ClInclude Include="Headers\Rendering\AnimationController.h" />

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="Source\Input\Input.cpp" />
     <ClCompile Include="Source\GameObjects\Types\GhostObject.cpp" />
     <ClCompile Include="Source\GameObjects\ObjectFactory.cpp" />
+    <ClCompile Include="Source\Rendering\BufferManager.cpp" />
     <ClCompile Include="Source\Tools\GpuMarkerVisualizer.cpp" />
     <ClCompile Include="Source\Tools\InputViewTool.cpp" />
     <ClCompile Include="Source\GameObjects\Types\LevelEditorCamera.cpp" />
@@ -189,6 +190,8 @@
     <ClInclude Include="Headers\Input\Input.h" />
     <ClInclude Include="Headers\Input\KeyCodes.h" />
     <ClInclude Include="Headers\Log.h" />
+    <ClInclude Include="Headers\Rendering\BufferManager.h" />
+    <ClInclude Include="Headers\Rendering\TextureManager.h" />
     <ClInclude Include="Headers\Tools\AudioParameters.h" />
     <ClInclude Include="Headers\Rendering\ModelLoading\ModelAnimation.h" />
     <ClInclude Include="Headers\Tools\BloomSettingsUI.h" />

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="Source\GameObjects\Types\GhostObject.cpp" />
     <ClCompile Include="Source\GameObjects\ObjectFactory.cpp" />
     <ClCompile Include="Source\Rendering\BufferManager.cpp" />
+    <ClCompile Include="Source\Rendering\TextureManager.cpp" />
     <ClCompile Include="Source\Tools\BufferVisualizer.cpp" />
     <ClCompile Include="Source\Tools\GpuMarkerVisualizer.cpp" />
     <ClCompile Include="Source\Tools\InputViewTool.cpp" />

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="Headers\Tools\GpuMarkerVisualizer.h" />
     <ClInclude Include="Headers\Tools\GridSettingsUI.h" />
     <ClInclude Include="Headers\Rendering\AnimationController.h" />
+    <ClInclude Include="Headers\Tools\TextureVisualizer.h" />
     <ClInclude Include="Headers\Tools\TonemapperSettings.h" />
     <ClInclude Include="Headers\UnitTesting.h" />
     <ClInclude Include="Headers\Utilities\FileWatch.h" />
@@ -293,6 +294,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\GameObjects\Types\TestObject.cpp" />
+    <ClCompile Include="Source\Tools\TextureVisualizer.cpp" />
     <ClCompile Include="Source\Tools\TonemapperSettings.cpp" />
     <ClCompile Include="Source\Rendering\Denoiser.cpp" />
     <ClCompile Include="Source\UnitTests\ObjectManagerTests.cpp" />

--- a/Engine/Headers/Rendering/BEAR/Buffer.h
+++ b/Engine/Headers/Rendering/BEAR/Buffer.h
@@ -4,6 +4,8 @@
 
 namespace Ball
 {
+	class BufferManager;
+
 	enum class BufferFlags
 	{
 		NONE = 0,
@@ -33,15 +35,6 @@ namespace Ball
 	class Buffer
 	{
 	public:
-		Buffer() = delete;
-
-		// Constructing a Buffer from CPU Data
-		Buffer(const void* data, const uint32_t stride, const uint32_t count, BufferFlags flags = BufferFlags::NONE,
-			   const std::string& name = "default_name");
-
-		// ToDo: GPU deallocator
-		~Buffer();
-
 		uint32_t GetNumElements() const { return m_Count; }
 		uint32_t GetStride() const { return m_Stride; } // in Bytes
 		uint32_t GetSizeBytes() const { return m_Count * m_Stride; } // in Bytes
@@ -52,6 +45,15 @@ namespace Ball
 		void Resize(uint32_t newCount);
 
 	private:
+		// Use BufferManager for BufferCreation and deletion
+		friend BufferManager;
+		Buffer() = delete;
+
+		Buffer(const void* data, const uint32_t stride, const uint32_t count, BufferFlags flags = BufferFlags::NONE,
+			   const std::string& name = "default_name");
+
+		~Buffer();
+
 		GPUBufferHandle m_BufferHandle;
 		std::string m_Name = "DEFAULT_NAME_FOR_BUFFER";
 		uint32_t m_Stride = 0;

--- a/Engine/Headers/Rendering/BEAR/Texture.h
+++ b/Engine/Headers/Rendering/BEAR/Texture.h
@@ -99,6 +99,7 @@ namespace Ball
 			return uint32_t(fmax(1.0, log2(fmax(float(m_Spec.m_Width), float(m_Spec.m_Height))) + 1.f));
 		}
 
+		// Note: Should be private, but because of MT Model Loading it's not - [ Angel 16/08/24 ]
 		void GenerateMips();
 
 	private:

--- a/Engine/Headers/Rendering/BEAR/Texture.h
+++ b/Engine/Headers/Rendering/BEAR/Texture.h
@@ -82,7 +82,6 @@ namespace Ball
 		TextureType GetType() const { return m_Spec.m_Type; }
 		uint32_t GetBytesPerChannel() const { return m_BytesPerChannel; }
 		uint32_t GetNumChannels() const { return m_Channels; }
-
 		uint32_t GetWidth() const { return m_Spec.m_Width; }
 		uint32_t GetHeight() const { return m_Spec.m_Height; }
 

--- a/Engine/Headers/Rendering/BEAR/Texture.h
+++ b/Engine/Headers/Rendering/BEAR/Texture.h
@@ -6,6 +6,8 @@
 
 namespace Ball
 {
+	class TextureManager;
+
 	enum class TextureFormat
 	{
 		R8G8B8A8_UNORM,
@@ -55,21 +57,11 @@ namespace Ball
 	class Texture
 	{
 	public:
-		Texture() = default;
-
-		// Constructs a texture from raw data
-		Texture(const void* data, TextureSpec spec, const std::string& name = "default_name");
-
-		// Constructs a texture from a provided path
-		Texture(const std::string& path, TextureSpec spec, const std::string& name = "default_name");
-
-		// Todo Texture GPU Deallocation (PS5)
-		~Texture();
-
 		// Only works for RenderTarget - Windows
 		// Workaround for `ResizeFrameBuffers`
 		// ToDo : For PS5 (all) and Windows (R and RW Tex).
 		void Resize(int newWidth, int newHeight);
+
 		void UpdateData(const void* data);
 
 		// Requests Texture data to be transferred to CPU
@@ -111,14 +103,17 @@ namespace Ball
 		void GenerateMips();
 
 	private:
+		friend TextureManager;
+		Texture() = default;
+		Texture(const void* data, TextureSpec spec, const std::string& name = "default_name");
+		~Texture();
+
 		uint32_t GetAlignedSize() const
 		{
 			const uint32_t rowPitch = m_Spec.m_Width * m_Channels * m_BytesPerChannel;
 			const uint32_t alignedRowPitch = Utilities::AlignToClosestUpper(rowPitch, 256);
 			return alignedRowPitch * m_Spec.m_Height;
 		}
-
-		void LoadTextureData(const void* data, const std::string& name);
 
 		TextureSpec m_Spec;
 		GPUTextureHandle m_TextureHandle = {};

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -5,6 +5,11 @@
 
 namespace Ball
 {
+	class BufferVisualizer;
+}
+
+namespace Ball
+{
 	class BufferManager
 	{
 	public:
@@ -21,6 +26,7 @@ namespace Ball
 		BufferManager(const BufferManager&) = delete;
 		BufferManager& operator=(const BufferManager&) = delete;
 
+		friend BufferVisualizer; // Uses this data to display info about Buffers
 		static inline std::unordered_set<Buffer*> m_Buffers;
 		static inline size_t m_BufferCount = 0;
 	};

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
-#include <unordered_set>
+#include <set>
+
 #include "BEAR/Buffer.h"
 
 namespace Ball
@@ -27,7 +28,7 @@ namespace Ball
 		BufferManager& operator=(const BufferManager&) = delete;
 
 		friend BufferVisualizer; // Uses this data to display info about Buffers
-		static inline std::unordered_set<Buffer*> m_Buffers;
+		static inline std::list<Buffer*> m_Buffers;
 		static inline size_t m_BufferCount = 0;
 	};
 } // namespace Ball

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <memory>
+#include <unordered_set>
+#include "BEAR/Buffer.h"
+
+namespace Ball
+{
+	class BufferManager
+	{
+	public:
+		static Buffer* CreateBuffer(const void* data, uint32_t stride, uint32_t count,
+									BufferFlags flags = BufferFlags::NONE, const std::string& name = "default_name");
+
+		static void DestroyBuffer(Buffer* buffer);
+		static void DestroyAllBuffers();
+
+		static size_t GetBufferCount() { return m_BufferCount; }
+
+	private:
+		BufferManager() = delete;
+		BufferManager(const BufferManager&) = delete;
+		BufferManager& operator=(const BufferManager&) = delete;
+
+		static inline std::unordered_set<Buffer*> m_Buffers;
+		static inline size_t m_BufferCount = 0;
+	};
+} // namespace Ball

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -14,13 +14,13 @@ namespace Ball
 	class BufferManager
 	{
 	public:
-		static Buffer* CreateBuffer(const void* data, uint32_t stride, uint32_t count,
-									BufferFlags flags = BufferFlags::NONE, const std::string& name = "default_name");
+		static Buffer* Create(const void* data, uint32_t stride, uint32_t count, BufferFlags flags = BufferFlags::NONE,
+							  const std::string& name = "default_name");
 
-		static void DestroyBuffer(Buffer* buffer);
-		static void DestroyAllBuffers();
+		static void Destroy(Buffer* buffer);
+		static void DestroyAll();
 
-		static size_t GetBufferCount() { return m_BufferCount; }
+		static size_t GetCount() { return m_BufferCount; }
 
 	private:
 		BufferManager() = delete;

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -1,29 +1,34 @@
 #pragma once
-#include <cstdint>
 
-#include "Shaders/ShaderHeaders/GpuModelStruct.h"
+#include "BEAR/Texture.h"
 
-namespace tinygltf
+namespace Ball
 {
-	struct Primitive;
+	class TextureVisualizer;
 }
 
 namespace Ball
 {
-	class Primitive
+	class TextureManager
 	{
 	public:
-		Primitive(const tinygltf::Primitive& primitive);
+		static Texture* Create(const void* data, TextureSpec spec, const std::string& name = "default_name");
 
-		uint32_t GetPositionIndex() const { return m_Data.m_PositionIndex; }
-		uint32_t GetIndexBufferIndex() const { return m_Data.m_IndexBufferId; }
-		uint32_t GetMaterialIndex() const { return m_Data.m_MaterialIndex; }
+		static Texture* CreateFromFilepath(const std::string& path, TextureSpec spec,
+										   const std::string& name = "default_name");
 
-		void SetMatrix(glm::mat4 mat) { m_Data.m_Model = mat; }
-		glm::mat4 GetMatrix() const { return m_Data.m_Model; }
+		static void Destroy(Texture* buffer);
+		static void DestroyAll();
+
+		static size_t GetCount() { return m_TextureCount; }
 
 	private:
-		PrimitiveGPU m_Data;
-	};
+		TextureManager() = delete;
+		TextureManager(const TextureManager&) = delete;
+		TextureManager& operator=(const TextureManager&) = delete;
 
+		friend TextureVisualizer; // Uses this data to display info about Textures
+		static inline std::list<Texture*> m_Textures;
+		static inline size_t m_TextureCount = 0;
+	};
 } // namespace Ball

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+#include "Shaders/ShaderHeaders/GpuModelStruct.h"
+
+namespace tinygltf
+{
+	struct Primitive;
+}
+
+namespace Ball
+{
+	class Primitive
+	{
+	public:
+		Primitive(const tinygltf::Primitive& primitive);
+
+		uint32_t GetPositionIndex() const { return m_Data.m_PositionIndex; }
+		uint32_t GetIndexBufferIndex() const { return m_Data.m_IndexBufferId; }
+		uint32_t GetMaterialIndex() const { return m_Data.m_MaterialIndex; }
+
+		void SetMatrix(glm::mat4 mat) { m_Data.m_Model = mat; }
+		glm::mat4 GetMatrix() const { return m_Data.m_Model; }
+
+	private:
+		PrimitiveGPU m_Data;
+	};
+
+} // namespace Ball

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -18,6 +18,12 @@ namespace Ball
 
 		static size_t GetCount() { return m_TextureCount; }
 
+		// Function to get TextureFormat as string
+		static std::string GetFormatAsString(const TextureFormat format);
+
+		// Function to get TextureType as string
+		static std::string GetTypeAsString(const TextureType type);
+
 	private:
 		TextureManager() = delete;
 		TextureManager(const TextureManager&) = delete;

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -5,10 +5,6 @@
 namespace Ball
 {
 	class TextureVisualizer;
-}
-
-namespace Ball
-{
 	class TextureManager
 	{
 	public:

--- a/Engine/Headers/Tools/BufferVisualizer.h
+++ b/Engine/Headers/Tools/BufferVisualizer.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "Tools/ToolBase.h"
 
 namespace Ball
 {
+
+	class Buffer;
+
 	class BufferVisualizer : public ToolBase
 	{
 	public:
@@ -14,6 +19,8 @@ namespace Ball
 		void Draw() override;
 
 	private:
+		std::unordered_set<Buffer*> m_SelectedBuffers;
+		int m_SelectedFlags = 0; // Variable to hold the selected flags
 	};
 
 } // namespace Ball

--- a/Engine/Headers/Tools/BufferVisualizer.h
+++ b/Engine/Headers/Tools/BufferVisualizer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Tools/ToolBase.h"
+
+namespace Ball
+{
+	class BufferVisualizer : public ToolBase
+	{
+	public:
+		void Init() override;
+
+		void Update() override {}
+		void Event() override {}
+		void Draw() override;
+
+	private:
+	};
+
+} // namespace Ball

--- a/Engine/Headers/Tools/TextureVisualizer.h
+++ b/Engine/Headers/Tools/TextureVisualizer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "Tools/ToolBase.h"
+
+namespace Ball
+{
+
+	class Texture;
+
+	class TextureVisualizer : public ToolBase
+	{
+	public:
+		void Init() override;
+
+		void Update() override {}
+		void Event() override {}
+		void Draw() override;
+
+	private:
+		std::unordered_set<Texture*> m_SelectedTextures;
+		int m_SelectedFlags = 0; // Variable to hold the selected flags
+	};
+
+} // namespace Ball

--- a/Engine/Headers/Tools/ToolManager.h
+++ b/Engine/Headers/Tools/ToolManager.h
@@ -10,6 +10,7 @@ namespace Ball
 		MENU,
 		ENGINE,
 		GRAPHICS,
+		RESOURCES,
 		MODIO,
 		PHYSICS,
 		AUDIO,
@@ -44,6 +45,7 @@ namespace Ball
 		}
 
 		void OpenTool(const std::string& name) const;
+		void CreateToolMenu(const char* menuName, ToolCatagory category) const;
 
 		// Tools
 		std::vector<ToolBase*> m_Tools;

--- a/Engine/Source/Input/Input.cpp
+++ b/Engine/Source/Input/Input.cpp
@@ -15,7 +15,8 @@ Input::Input()
 Input::~Input()
 {
 	// Before we shutdown, stop all vibration
-	SetControllerVibration(controllerMotor::MOTORBOTH, 0);
+	if (IsControllerConnected())
+		SetControllerVibration(controllerMotor::MOTORBOTH, 0);
 
 	INFO(LOG_INPUT, "Input system got destroyed...");
 }

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -1,0 +1,30 @@
+#include "Rendering/BufferManager.h"
+
+namespace Ball
+{
+	Buffer* BufferManager::CreateBuffer(const void* data, uint32_t stride, uint32_t count, BufferFlags flags,
+										const std::string& name)
+	{
+		const auto buffer = new Buffer(data, stride, count, flags, name);
+		m_Buffers.insert(buffer);
+		m_BufferCount++;
+		return buffer;
+	}
+
+	void BufferManager::DestroyBuffer(Buffer* buffer)
+	{
+		if (m_Buffers.erase(buffer) > 0)
+		{
+			delete buffer;
+			m_BufferCount--;
+		}
+	}
+
+	void BufferManager::DestroyAllBuffers()
+	{
+		for (auto& buf : m_Buffers)
+		{
+			delete buf;
+		}
+	}
+} // namespace Ball

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -6,18 +6,16 @@ namespace Ball
 										const std::string& name)
 	{
 		const auto buffer = new Buffer(data, stride, count, flags, name);
-		m_Buffers.insert(buffer);
+		m_Buffers.push_back(buffer);
 		m_BufferCount++;
 		return buffer;
 	}
 
 	void BufferManager::DestroyBuffer(Buffer* buffer)
 	{
-		if (m_Buffers.erase(buffer) > 0)
-		{
-			delete buffer;
-			m_BufferCount--;
-		}
+		m_Buffers.remove(buffer);
+		delete buffer;
+		m_BufferCount--;
 	}
 
 	void BufferManager::DestroyAllBuffers()

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -2,8 +2,8 @@
 
 namespace Ball
 {
-	Buffer* BufferManager::CreateBuffer(const void* data, uint32_t stride, uint32_t count, BufferFlags flags,
-										const std::string& name)
+	Buffer* BufferManager::Create(const void* data, uint32_t stride, uint32_t count, BufferFlags flags,
+								  const std::string& name)
 	{
 		const auto buffer = new Buffer(data, stride, count, flags, name);
 		m_Buffers.push_back(buffer);
@@ -11,14 +11,14 @@ namespace Ball
 		return buffer;
 	}
 
-	void BufferManager::DestroyBuffer(Buffer* buffer)
+	void BufferManager::Destroy(Buffer* buffer)
 	{
 		m_Buffers.remove(buffer);
 		delete buffer;
 		m_BufferCount--;
 	}
 
-	void BufferManager::DestroyAllBuffers()
+	void BufferManager::DestroyAll()
 	{
 		for (auto& buf : m_Buffers)
 		{

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -20,9 +20,11 @@ namespace Ball
 
 	void BufferManager::DestroyAll()
 	{
-		for (auto& buf : m_Buffers)
-		{
+		m_BufferCount = 0;
+
+		for (const auto& buf : m_Buffers)
 			delete buf;
-		}
+
+		m_Buffers.clear();
 	}
 } // namespace Ball

--- a/Engine/Source/Rendering/Denoiser.cpp
+++ b/Engine/Source/Rendering/Denoiser.cpp
@@ -6,6 +6,7 @@
 #include "Shaders/ShaderHeaders/CameraGPU.h"
 #include <imgui.h>
 
+#include "Rendering/BufferManager.h"
 #include "Utilities/RenderUtilities.h"
 
 using namespace Ball;
@@ -124,9 +125,10 @@ void Denoiser::Initialize(int windowWidth, int windowHeight)
 		}
 
 		if (screensize)
-			m_Buffers[i] = new Buffer(nullptr, stride, count, (flags | BufferFlags::SCREENSIZE), name.c_str());
+			m_Buffers[i] =
+				BufferManager::CreateBuffer(nullptr, stride, count, (flags | BufferFlags::SCREENSIZE), name.c_str());
 		else
-			m_Buffers[i] = new Buffer(nullptr, stride, count, flags, name.c_str());
+			m_Buffers[i] = BufferManager::CreateBuffer(nullptr, stride, count, flags, name.c_str());
 	}
 }
 
@@ -134,7 +136,7 @@ Denoiser::~Denoiser()
 {
 	for (Buffer* buffer : m_Buffers)
 	{
-		delete buffer;
+		BufferManager::DestroyBuffer(buffer);
 	}
 
 	delete m_CalculateWeightPipeline;

--- a/Engine/Source/Rendering/Denoiser.cpp
+++ b/Engine/Source/Rendering/Denoiser.cpp
@@ -126,9 +126,9 @@ void Denoiser::Initialize(int windowWidth, int windowHeight)
 
 		if (screensize)
 			m_Buffers[i] =
-				BufferManager::CreateBuffer(nullptr, stride, count, (flags | BufferFlags::SCREENSIZE), name.c_str());
+				BufferManager::Create(nullptr, stride, count, (flags | BufferFlags::SCREENSIZE), name.c_str());
 		else
-			m_Buffers[i] = BufferManager::CreateBuffer(nullptr, stride, count, flags, name.c_str());
+			m_Buffers[i] = BufferManager::Create(nullptr, stride, count, flags, name.c_str());
 	}
 }
 
@@ -136,7 +136,7 @@ Denoiser::~Denoiser()
 {
 	for (Buffer* buffer : m_Buffers)
 	{
-		BufferManager::DestroyBuffer(buffer);
+		BufferManager::Destroy(buffer);
 	}
 
 	delete m_CalculateWeightPipeline;

--- a/Engine/Source/Rendering/ModelLoading/ModelManager.cpp
+++ b/Engine/Source/Rendering/ModelLoading/ModelManager.cpp
@@ -41,9 +41,9 @@ namespace Ball
 	ModelManager::~ModelManager()
 	{
 		delete m_TLAS;
-		BufferManager::DestroyBuffer(m_LightData);
-		BufferManager::DestroyBuffer(m_ModelHeapLocationBuffer);
-		BufferManager::DestroyBuffer(m_InstanceTransformsBuffer);
+		BufferManager::Destroy(m_LightData);
+		BufferManager::Destroy(m_ModelHeapLocationBuffer);
+		BufferManager::Destroy(m_InstanceTransformsBuffer);
 	}
 
 	void ModelManager::RequestReloadModels()
@@ -170,12 +170,12 @@ namespace Ball
 			}
 		}
 
-		BufferManager::DestroyBuffer(m_ModelHeapLocationBuffer);
-		m_ModelHeapLocationBuffer = BufferManager::CreateBuffer(cpuBuffer.data(),
-																sizeof(cpuBuffer[0]),
-																cpuBuffer.size(),
-																BufferFlags::SRV | BufferFlags::DEFAULT_HEAP,
-																"World Info Buffer");
+		BufferManager::Destroy(m_ModelHeapLocationBuffer);
+		m_ModelHeapLocationBuffer = BufferManager::Create(cpuBuffer.data(),
+														  sizeof(cpuBuffer[0]),
+														  cpuBuffer.size(),
+														  BufferFlags::SRV | BufferFlags::DEFAULT_HEAP,
+														  "World Info Buffer");
 
 		rdhToStoreModels.Switch(*m_ModelHeapLocationBuffer, RDH_MODEL_DATA);
 
@@ -310,12 +310,12 @@ namespace Ball
 			instanceTransforms.push_back(instance->m_Transform);
 		}
 
-		BufferManager::DestroyBuffer(m_InstanceTransformsBuffer);
-		m_InstanceTransformsBuffer = BufferManager::CreateBuffer(instanceTransforms.data(),
-																 sizeof(glm::mat4),
-																 tlasConstructionData.size(),
-																 BufferFlags::SRV | BufferFlags::UPLOAD_HEAP,
-																 "Transform Buffer");
+		BufferManager::Destroy(m_InstanceTransformsBuffer);
+		m_InstanceTransformsBuffer = BufferManager::Create(instanceTransforms.data(),
+														   sizeof(glm::mat4),
+														   tlasConstructionData.size(),
+														   BufferFlags::SRV | BufferFlags::UPLOAD_HEAP,
+														   "Transform Buffer");
 		rdhToStoreTLASBuffers.Switch(*m_InstanceTransformsBuffer, RDH_TRANSFORMS);
 
 		m_TLAS = new TLAS(tlasConstructionData);
@@ -325,7 +325,7 @@ namespace Ball
 
 	void ModelManager::FillInLights()
 	{
-		BufferManager::DestroyBuffer(m_LightData);
+		BufferManager::Destroy(m_LightData);
 
 		std::vector<GameObject*> objectsWithModels;
 		for (auto const& object : GetLevel().GetObjectManager())
@@ -356,11 +356,11 @@ namespace Ball
 
 		ASSERT_MSG(LOG_GRAPHICS, !lightDataCPU.empty(), "We do not support having no light sources in a scene!");
 
-		m_LightData = BufferManager::CreateBuffer(lightDataCPU.data(),
-												  sizeof(LightPickData),
-												  lightDataCPU.size(),
-												  (BufferFlags::SRV | BufferFlags::DEFAULT_HEAP),
-												  "Lights");
+		m_LightData = BufferManager::Create(lightDataCPU.data(),
+											sizeof(LightPickData),
+											lightDataCPU.size(),
+											(BufferFlags::SRV | BufferFlags::DEFAULT_HEAP),
+											"Lights");
 	}
 
 	std::vector<TlasInstanceData*> ModelManager::CreateTlasInstanceData()

--- a/Engine/Source/Rendering/ModelLoading/ModelManager.cpp
+++ b/Engine/Source/Rendering/ModelLoading/ModelManager.cpp
@@ -25,6 +25,8 @@
 #include "Timer.h"
 #include <unordered_set>
 
+#include "Rendering/BufferManager.h"
+
 #ifdef USE_THREADED_MODEL_LOADING
 #include <execution>
 #include <mutex>
@@ -38,11 +40,10 @@ namespace Ball
 
 	ModelManager::~ModelManager()
 	{
-		delete m_LightData;
-
 		delete m_TLAS;
-		delete m_ModelHeapLocationBuffer;
-		delete m_InstanceTransformsBuffer;
+		BufferManager::DestroyBuffer(m_LightData);
+		BufferManager::DestroyBuffer(m_ModelHeapLocationBuffer);
+		BufferManager::DestroyBuffer(m_InstanceTransformsBuffer);
 	}
 
 	void ModelManager::RequestReloadModels()
@@ -169,12 +170,12 @@ namespace Ball
 			}
 		}
 
-		delete m_ModelHeapLocationBuffer;
-		m_ModelHeapLocationBuffer = new Buffer(cpuBuffer.data(),
-											   sizeof(cpuBuffer[0]),
-											   cpuBuffer.size(),
-											   BufferFlags::SRV | BufferFlags::DEFAULT_HEAP,
-											   "World Info Buffer");
+		BufferManager::DestroyBuffer(m_ModelHeapLocationBuffer);
+		m_ModelHeapLocationBuffer = BufferManager::CreateBuffer(cpuBuffer.data(),
+																sizeof(cpuBuffer[0]),
+																cpuBuffer.size(),
+																BufferFlags::SRV | BufferFlags::DEFAULT_HEAP,
+																"World Info Buffer");
 
 		rdhToStoreModels.Switch(*m_ModelHeapLocationBuffer, RDH_MODEL_DATA);
 
@@ -309,12 +310,12 @@ namespace Ball
 			instanceTransforms.push_back(instance->m_Transform);
 		}
 
-		delete m_InstanceTransformsBuffer;
-		m_InstanceTransformsBuffer = new Buffer(instanceTransforms.data(),
-												sizeof(glm::mat4),
-												tlasConstructionData.size(),
-												BufferFlags::SRV | BufferFlags::UPLOAD_HEAP,
-												"Transform Buffer");
+		BufferManager::DestroyBuffer(m_InstanceTransformsBuffer);
+		m_InstanceTransformsBuffer = BufferManager::CreateBuffer(instanceTransforms.data(),
+																 sizeof(glm::mat4),
+																 tlasConstructionData.size(),
+																 BufferFlags::SRV | BufferFlags::UPLOAD_HEAP,
+																 "Transform Buffer");
 		rdhToStoreTLASBuffers.Switch(*m_InstanceTransformsBuffer, RDH_TRANSFORMS);
 
 		m_TLAS = new TLAS(tlasConstructionData);
@@ -324,7 +325,7 @@ namespace Ball
 
 	void ModelManager::FillInLights()
 	{
-		delete m_LightData;
+		BufferManager::DestroyBuffer(m_LightData);
 
 		std::vector<GameObject*> objectsWithModels;
 		for (auto const& object : GetLevel().GetObjectManager())
@@ -355,11 +356,11 @@ namespace Ball
 
 		ASSERT_MSG(LOG_GRAPHICS, !lightDataCPU.empty(), "We do not support having no light sources in a scene!");
 
-		m_LightData = new Buffer(lightDataCPU.data(),
-								 sizeof(LightPickData),
-								 lightDataCPU.size(),
-								 (BufferFlags::SRV | BufferFlags::DEFAULT_HEAP),
-								 "Lights");
+		m_LightData = BufferManager::CreateBuffer(lightDataCPU.data(),
+												  sizeof(LightPickData),
+												  lightDataCPU.size(),
+												  (BufferFlags::SRV | BufferFlags::DEFAULT_HEAP),
+												  "Lights");
 	}
 
 	std::vector<TlasInstanceData*> ModelManager::CreateTlasInstanceData()

--- a/Engine/Source/Rendering/TextureManager.cpp
+++ b/Engine/Source/Rendering/TextureManager.cpp
@@ -39,10 +39,56 @@ Texture* TextureManager::CreateFromFilepath(const std::string& path, TextureSpec
 	return texture;
 }
 
-void TextureManager::Destroy(Texture* buffer)
+void TextureManager::Destroy(Texture* texture)
 {
+	m_Textures.remove(texture);
+	delete texture;
+	m_TextureCount--;
 }
 
 void TextureManager::DestroyAll()
 {
+	m_TextureCount = 0;
+
+	for (auto& tex : m_Textures)
+		delete tex;
+
+	m_Textures.clear();
+}
+
+std::string TextureManager::GetFormatAsString(const TextureFormat format)
+{
+	switch (format)
+	{
+	case TextureFormat::R8G8B8A8_UNORM:
+		return "R8G8B8A8_UNORM";
+	case TextureFormat::R8G8B8A8_SNORM:
+		return "R8G8B8A8_SNORM";
+	case TextureFormat::R16G16B16A16_UNORM:
+		return "R16G16B16A16_UNORM";
+	case TextureFormat::R32_FLOAT:
+		return "R32_FLOAT";
+	case TextureFormat::R32_G32_FLOAT:
+		return "R32_G32_FLOAT";
+	case TextureFormat::R32_G32_B32_A32_FLOAT:
+		return "R32_G32_B32_A32_FLOAT";
+	default:
+		ASSERT_MSG(LOG_GRAPHICS, false, "Unknown Format of Texture");
+		return "Unknown Format";
+	}
+}
+std::string TextureManager::GetTypeAsString(const TextureType type)
+{
+	switch (type)
+	{
+	case TextureType::RENDER_TARGET:
+		return "RENDER_TARGET";
+	case TextureType::R_TEXTURE:
+		return "R_TEXTURE";
+	case TextureType::RW_TEXTURE:
+		return "RW_TEXTURE";
+	default:
+		ASSERT_MSG(LOG_GRAPHICS, false, "Unknown Type of Texture");
+		return "Unknown Type";
+	}
 }

--- a/Engine/Source/Rendering/TextureManager.cpp
+++ b/Engine/Source/Rendering/TextureManager.cpp
@@ -1,0 +1,48 @@
+#include "Rendering/TextureManager.h"
+
+#include <stb/stb_image.h>
+
+#include "FileIO.h"
+#include "Log.h"
+
+#include "Rendering/BEAR/Texture.h"
+
+using namespace Ball;
+
+Texture* TextureManager::Create(const void* data, TextureSpec spec, const std::string& name)
+{
+	Texture* texture = new Texture(data, spec, name);
+	m_Textures.push_back(texture);
+	m_TextureCount++;
+	return texture;
+}
+
+Texture* TextureManager::CreateFromFilepath(const std::string& path, TextureSpec spec, const std::string& name)
+{
+	ASSERT_MSG(LOG_GRAPHICS, FileIO::Exist(FileIO::Engine, path), "Texture path doesn't exist: '%s'", path.c_str());
+	std::string texturepath = FileIO::GetPath(FileIO::Engine, path);
+
+	int width, height, channels;
+	auto* data = stbi_loadf(texturepath.c_str(), &width, &height, &channels, 4);
+
+	// HACK : I dislike how the width and the height get overwritten here for the texture spec
+	// and that you're able to pass a texture spec whenever loading an image from a path
+	// This needs to get thought out more - Angel [ 16/08/24 ]
+	spec.m_Width = width;
+	spec.m_Height = height;
+
+	if (!data)
+		ASSERT_MSG(LOG_GRAPHICS, false, "stbi_load() failed in Texture constructor for %s", path.c_str());
+
+	Texture* texture = Create(data, spec, name);
+	stbi_image_free(data);
+	return texture;
+}
+
+void TextureManager::Destroy(Texture* buffer)
+{
+}
+
+void TextureManager::DestroyAll()
+{
+}

--- a/Engine/Source/Tools/BufferVisualizer.cpp
+++ b/Engine/Source/Tools/BufferVisualizer.cpp
@@ -1,0 +1,76 @@
+#include "Tools/BufferVisualizer.h"
+
+#include "imgui.h"
+#include "Rendering/BufferManager.h"
+
+using namespace Ball;
+
+void BufferVisualizer::Init()
+{
+	m_Open = false;
+	m_Name = "Buffer Visualizer";
+	m_ToolCatagory = ToolCatagory::RESOURCES;
+	m_ToolInterfaceType = ToolInterfaceType::WINDOW;
+}
+
+void BufferVisualizer::Draw()
+{
+	ImGui::Begin(m_Name.c_str(), &m_Open);
+	static char searchBuffer[128] = "";
+	ImGui::InputText("Search", searchBuffer, IM_ARRAYSIZE(searchBuffer));
+
+	// Sorting options
+	static int sortOption = 0; // 0 = None, 1 = Ascending, 2 = Descending
+	ImGui::Combo("Sort by", &sortOption, "None\0Name (Ascending)\0Name (Descending)\0");
+
+	// Copy unordered_set to vector for sorting and filtering
+	std::vector<Buffer*> filteredBuffers;
+	for (auto& buffer : BufferManager::m_Buffers)
+	{
+		if (strlen(searchBuffer) == 0 || buffer->GetName().find(searchBuffer) != std::string::npos)
+		{
+			filteredBuffers.push_back(buffer);
+		}
+	}
+
+	// Sort the vector based on the selected option
+	if (sortOption == 1)
+	{
+		std::sort(filteredBuffers.begin(),
+				  filteredBuffers.end(),
+				  [](Buffer* a, Buffer* b) { return a->GetName() < b->GetName(); });
+	}
+	else if (sortOption == 2)
+	{
+		std::sort(filteredBuffers.begin(),
+				  filteredBuffers.end(),
+				  [](Buffer* a, Buffer* b) { return a->GetName() > b->GetName(); });
+	}
+
+	static Buffer* selectedBuffer = nullptr;
+	int index = 0;
+
+	for (auto& buffer : filteredBuffers)
+	{
+		std::string label = std::to_string(index) + ": " + buffer->GetName();
+		if (ImGui::Selectable(label.c_str(), buffer == selectedBuffer))
+		{
+			selectedBuffer = buffer;
+		}
+		index++;
+	}
+
+	if (selectedBuffer)
+	{
+		ImGui::Separator();
+		ImGui::Text("Buffer Details:");
+		ImGui::Text("Name: %s", selectedBuffer->GetName().c_str());
+		ImGui::Text("Number of Elements: %u", selectedBuffer->GetNumElements());
+		ImGui::Text("Stride: %u Bytes", selectedBuffer->GetStride());
+		ImGui::Text("Size: %u Bytes", selectedBuffer->GetSizeBytes());
+
+		// Displaying flags and handle might require custom code depending on their structures.
+	}
+
+	ImGui::End();
+}

--- a/Engine/Source/Tools/BufferVisualizer.cpp
+++ b/Engine/Source/Tools/BufferVisualizer.cpp
@@ -5,6 +5,9 @@
 
 using namespace Ball;
 
+bool IsFlagSet(int flags, int flag);
+void RenderMultiSelectCombo(const char* label, int& selectedFlags, const std::vector<std::string>& items);
+
 void BufferVisualizer::Init()
 {
 	m_Open = false;
@@ -16,61 +19,170 @@ void BufferVisualizer::Init()
 void BufferVisualizer::Draw()
 {
 	ImGui::Begin(m_Name.c_str(), &m_Open);
-	static char searchBuffer[128] = "";
-	ImGui::InputText("Search", searchBuffer, IM_ARRAYSIZE(searchBuffer));
+	static char searchField[128] = "";
+	ImGui::InputText("Search", searchField, IM_ARRAYSIZE(searchField));
 
 	// Sorting options
 	static int sortOption = 0; // 0 = None, 1 = Ascending, 2 = Descending
-	ImGui::Combo("Sort by", &sortOption, "None\0Name (Ascending)\0Name (Descending)\0");
+	const char* sortItems[] = {
+		"None",
+		"Name (Ascending)",
+		"Name (Descending)",
+	};
+
+	ImGui::Combo("Sort by", &sortOption, sortItems, IM_ARRAYSIZE(sortItems));
+
+	const std::vector<std::string> items = {
+		"NONE", "CBV", "SRV", "UAV", "ALLOW_UA", "DEFAULT_HEAP", "UPLOAD_HEAP", "VERTEX_BUFFER", "SCREENSIZE"};
+
+	if (ImGui::BeginCombo("Filter", "Select..."))
+	{
+		for (int i = 0; i < items.size(); ++i)
+		{
+			bool isSelected = IsFlagSet(m_SelectedFlags, 1 << i);
+			if (ImGui::Checkbox(items[i].c_str(), &isSelected))
+			{
+				if (isSelected)
+					m_SelectedFlags |= (1 << i); // Set the flag
+				else
+					m_SelectedFlags &= ~(1 << i); // Clear the flag
+			}
+		}
+		ImGui::EndCombo();
+	}
 
 	// Copy unordered_set to vector for sorting and filtering
-	std::vector<Buffer*> filteredBuffers;
+	std::vector<Buffer*> nameFilteredBuffers;
+	nameFilteredBuffers.reserve(BufferManager::m_Buffers.size());
 	for (auto& buffer : BufferManager::m_Buffers)
 	{
-		if (strlen(searchBuffer) == 0 || buffer->GetName().find(searchBuffer) != std::string::npos)
+		// Add the buffers the correspond with the search field
+		if (strlen(searchField) == 0 || buffer->GetName().find(searchField) != std::string::npos)
 		{
-			filteredBuffers.push_back(buffer);
+			nameFilteredBuffers.push_back(buffer);
+		}
+	}
+
+	// Copy unordered_set to vector for sorting and filtering
+	std::vector<Buffer*> flagFilteredBuffers;
+	flagFilteredBuffers.reserve(nameFilteredBuffers.size());
+	for (auto& buffer : nameFilteredBuffers)
+	{
+		if (((int)buffer->GetFlags() & m_SelectedFlags) == m_SelectedFlags)
+		{
+			flagFilteredBuffers.push_back(buffer);
 		}
 	}
 
 	// Sort the vector based on the selected option
 	if (sortOption == 1)
 	{
-		std::sort(filteredBuffers.begin(),
-				  filteredBuffers.end(),
+		std::sort(flagFilteredBuffers.begin(),
+				  flagFilteredBuffers.end(),
 				  [](Buffer* a, Buffer* b) { return a->GetName() < b->GetName(); });
 	}
 	else if (sortOption == 2)
 	{
-		std::sort(filteredBuffers.begin(),
-				  filteredBuffers.end(),
+		std::sort(flagFilteredBuffers.begin(),
+				  flagFilteredBuffers.end(),
 				  [](Buffer* a, Buffer* b) { return a->GetName() > b->GetName(); });
 	}
 
-	static Buffer* selectedBuffer = nullptr;
 	int index = 0;
 
-	for (auto& buffer : filteredBuffers)
+	std::unordered_set<Buffer*> toDelete;
+	for (auto& buffer : flagFilteredBuffers)
 	{
 		std::string label = std::to_string(index) + ": " + buffer->GetName();
-		if (ImGui::Selectable(label.c_str(), buffer == selectedBuffer))
+		bool isSelected = m_SelectedBuffers.find(buffer) != m_SelectedBuffers.end();
+		if (ImGui::Selectable(label.c_str(), &isSelected))
 		{
-			selectedBuffer = buffer;
+			m_SelectedBuffers.insert(buffer);
+
+			// Clear if you've deselected a buffer
+			if (!isSelected)
+				toDelete.insert(buffer);
 		}
+
 		index++;
 	}
 
-	if (selectedBuffer)
+	for (auto selectedBuffer : m_SelectedBuffers)
 	{
-		ImGui::Separator();
-		ImGui::Text("Buffer Details:");
-		ImGui::Text("Name: %s", selectedBuffer->GetName().c_str());
+		std::string name = "Name: " + selectedBuffer->GetName();
+
+		bool open = true;
+		ImGui::Begin(name.c_str(), &open);
+		ImGui::Text("%s", name.c_str());
 		ImGui::Text("Number of Elements: %u", selectedBuffer->GetNumElements());
 		ImGui::Text("Stride: %u Bytes", selectedBuffer->GetStride());
 		ImGui::Text("Size: %u Bytes", selectedBuffer->GetSizeBytes());
 
-		// Displaying flags and handle might require custom code depending on their structures.
+		// Display each flag if it is set
+		BufferFlags flags = selectedBuffer->GetFlags();
+
+		if (flags == BufferFlags::NONE)
+		{
+			ImGui::Text("Flags: NONE");
+		}
+		else
+		{
+			ImGui::Text("Flags:");
+			if ((flags & BufferFlags::CBV) != BufferFlags::NONE)
+				ImGui::BulletText("CBV");
+			if ((flags & BufferFlags::SRV) != BufferFlags::NONE)
+				ImGui::BulletText("SRV");
+			if ((flags & BufferFlags::UAV) != BufferFlags::NONE)
+				ImGui::BulletText("UAV");
+			if ((flags & BufferFlags::ALLOW_UA) != BufferFlags::NONE)
+				ImGui::BulletText("ALLOW_UA");
+			if ((flags & BufferFlags::DEFAULT_HEAP) != BufferFlags::NONE)
+				ImGui::BulletText("DEFAULT_HEAP");
+			if ((flags & BufferFlags::UPLOAD_HEAP) != BufferFlags::NONE)
+				ImGui::BulletText("UPLOAD_HEAP");
+			if ((flags & BufferFlags::VERTEX_BUFFER) != BufferFlags::NONE)
+				ImGui::BulletText("VERTEX_BUFFER");
+			if ((flags & BufferFlags::SCREENSIZE) != BufferFlags::NONE)
+				ImGui::BulletText("SCREENSIZE");
+		}
+
+		if (!open)
+			toDelete.insert(selectedBuffer);
+
+		ImGui::End();
+	}
+
+	// Cleanup
+	for (const auto& buffer : toDelete)
+	{
+		m_SelectedBuffers.erase(buffer);
 	}
 
 	ImGui::End();
+}
+
+// Utility function to check if a flag is set
+bool IsFlagSet(int flags, int flag)
+{
+	return (flags & flag) == flag;
+}
+
+// Function to render the multi-select combo box
+void RenderMultiSelectCombo(const char* label, int& selectedFlags, const std::vector<std::string>& items)
+{
+	if (ImGui::BeginCombo(label, "Select..."))
+	{
+		for (int i = 0; i < items.size(); ++i)
+		{
+			bool isSelected = IsFlagSet(selectedFlags, 1 << i);
+			if (ImGui::Checkbox(items[i].c_str(), &isSelected))
+			{
+				if (isSelected)
+					selectedFlags |= (1 << i); // Set the flag
+				else
+					selectedFlags &= ~(1 << i); // Clear the flag
+			}
+		}
+		ImGui::EndCombo();
+	}
 }

--- a/Engine/Source/Tools/TextureVisualizer.cpp
+++ b/Engine/Source/Tools/TextureVisualizer.cpp
@@ -5,7 +5,6 @@
 
 using namespace Ball;
 
-bool IsFlagSetA(int flags, int flag);
 void RenderMultiSelectComboA(const char* label, int& selectedFlags, const std::vector<std::string>& items);
 
 void TextureVisualizer::Init()
@@ -30,26 +29,9 @@ void TextureVisualizer::Draw()
 		"Name (Descending)",
 	};
 
-	ImGui::Combo("Sort by", &sortOption, sortItems, IM_ARRAYSIZE(sortItems));
-
-	const std::vector<std::string> items = {
-		"NONE", "CBV", "SRV", "UAV", "ALLOW_UA", "DEFAULT_HEAP", "UPLOAD_HEAP", "VERTEX_Texture", "SCREENSIZE"};
-
-	if (ImGui::BeginCombo("Filter", "Select..."))
-	{
-		for (int i = 0; i < items.size(); ++i)
-		{
-			bool isSelected = IsFlagSetA(m_SelectedFlags, 1 << i);
-			if (ImGui::Checkbox(items[i].c_str(), &isSelected))
-			{
-				if (isSelected)
-					m_SelectedFlags |= (1 << i); // Set the flag
-				else
-					m_SelectedFlags &= ~(1 << i); // Clear the flag
-			}
-		}
-		ImGui::EndCombo();
-	}
+	ImGui::Combo("Sort by Flags", &sortOption, sortItems, IM_ARRAYSIZE(sortItems));
+	const std::vector<std::string> comboFlags = {"NONE", "MIPMAP_GENERATE", "ALLOW_UA", "SCREENSIZE"};
+	RenderMultiSelectComboA("Filter", m_SelectedFlags, comboFlags);
 
 	// Copy unordered_set to vector for sorting and filtering
 	std::vector<Texture*> nameFilteredTextures;
@@ -88,8 +70,8 @@ void TextureVisualizer::Draw()
 				  [](Texture* a, Texture* b) { return a->GetName() > b->GetName(); });
 	}
 
+	// List all Textures as selectable items
 	int index = 0;
-
 	std::unordered_set<Texture*> toDelete;
 	for (auto& Texture : flagFilteredTextures)
 	{
@@ -103,7 +85,6 @@ void TextureVisualizer::Draw()
 			if (!isSelected)
 				toDelete.insert(Texture);
 		}
-
 		index++;
 	}
 
@@ -114,11 +95,13 @@ void TextureVisualizer::Draw()
 		bool open = true;
 		ImGui::Begin(name.c_str(), &open);
 		ImGui::Text("%s", name.c_str());
-		ImGui::Text("Width: %u Bytes", selectedTexture->GetWidth());
-		ImGui::Text("Height: %u Bytes", selectedTexture->GetHeight());
-		ImGui::Text("Aligned Width: %u Bytes", selectedTexture->GetAlignedWidth());
+		ImGui::Text("Type: %s", TextureManager::GetTypeAsString(selectedTexture->GetType()).c_str());
+		ImGui::Text("Format: %s", TextureManager::GetFormatAsString(selectedTexture->GetFormat()).c_str());
+		ImGui::Text("Width: %u", selectedTexture->GetWidth());
+		ImGui::Text("Height: %u", selectedTexture->GetHeight());
+		ImGui::Text("Aligned Width: %u", selectedTexture->GetAlignedWidth());
 		ImGui::Text("Number of Channels: %u", selectedTexture->GetNumChannels());
-		ImGui::Text("Bytes per Channel: %u Bytes", selectedTexture->GetBytesPerChannel());
+		ImGui::Text("Bytes per Channel: %u", selectedTexture->GetBytesPerChannel());
 		ImGui::Text("Size: %u Bytes",
 					selectedTexture->GetAlignedWidth() * selectedTexture->GetHeight() *
 						selectedTexture->GetBytesPerChannel() * selectedTexture->GetNumChannels());

--- a/Engine/Source/Tools/TextureVisualizer.cpp
+++ b/Engine/Source/Tools/TextureVisualizer.cpp
@@ -1,0 +1,183 @@
+#include "Tools/TextureVisualizer.h"
+
+#include "imgui.h"
+#include "Rendering/TextureManager.h"
+
+using namespace Ball;
+
+bool IsFlagSetA(int flags, int flag);
+void RenderMultiSelectComboA(const char* label, int& selectedFlags, const std::vector<std::string>& items);
+
+void TextureVisualizer::Init()
+{
+	m_Open = false;
+	m_Name = "Texture Visualizer";
+	m_ToolCatagory = ToolCatagory::RESOURCES;
+	m_ToolInterfaceType = ToolInterfaceType::WINDOW;
+}
+
+void TextureVisualizer::Draw()
+{
+	ImGui::Begin(m_Name.c_str(), &m_Open);
+	static char searchField[128] = "";
+	ImGui::InputText("Search", searchField, IM_ARRAYSIZE(searchField));
+
+	// Sorting options
+	static int sortOption = 0; // 0 = None, 1 = Ascending, 2 = Descending
+	const char* sortItems[] = {
+		"None",
+		"Name (Ascending)",
+		"Name (Descending)",
+	};
+
+	ImGui::Combo("Sort by", &sortOption, sortItems, IM_ARRAYSIZE(sortItems));
+
+	const std::vector<std::string> items = {
+		"NONE", "CBV", "SRV", "UAV", "ALLOW_UA", "DEFAULT_HEAP", "UPLOAD_HEAP", "VERTEX_Texture", "SCREENSIZE"};
+
+	if (ImGui::BeginCombo("Filter", "Select..."))
+	{
+		for (int i = 0; i < items.size(); ++i)
+		{
+			bool isSelected = IsFlagSetA(m_SelectedFlags, 1 << i);
+			if (ImGui::Checkbox(items[i].c_str(), &isSelected))
+			{
+				if (isSelected)
+					m_SelectedFlags |= (1 << i); // Set the flag
+				else
+					m_SelectedFlags &= ~(1 << i); // Clear the flag
+			}
+		}
+		ImGui::EndCombo();
+	}
+
+	// Copy unordered_set to vector for sorting and filtering
+	std::vector<Texture*> nameFilteredTextures;
+	nameFilteredTextures.reserve(TextureManager::m_Textures.size());
+	for (auto& Texture : TextureManager::m_Textures)
+	{
+		// Add the Textures the correspond with the search field
+		if (strlen(searchField) == 0 || Texture->GetName().find(searchField) != std::string::npos)
+		{
+			nameFilteredTextures.push_back(Texture);
+		}
+	}
+
+	// Copy unordered_set to vector for sorting and filtering
+	std::vector<Texture*> flagFilteredTextures;
+	flagFilteredTextures.reserve(nameFilteredTextures.size());
+	for (auto& Texture : nameFilteredTextures)
+	{
+		if (((int)Texture->GetFlags() & m_SelectedFlags) == m_SelectedFlags)
+		{
+			flagFilteredTextures.push_back(Texture);
+		}
+	}
+
+	// Sort the vector based on the selected option
+	if (sortOption == 1)
+	{
+		std::sort(flagFilteredTextures.begin(),
+				  flagFilteredTextures.end(),
+				  [](Texture* a, Texture* b) { return a->GetName() < b->GetName(); });
+	}
+	else if (sortOption == 2)
+	{
+		std::sort(flagFilteredTextures.begin(),
+				  flagFilteredTextures.end(),
+				  [](Texture* a, Texture* b) { return a->GetName() > b->GetName(); });
+	}
+
+	int index = 0;
+
+	std::unordered_set<Texture*> toDelete;
+	for (auto& Texture : flagFilteredTextures)
+	{
+		std::string label = std::to_string(index) + ": " + Texture->GetName();
+		bool isSelected = m_SelectedTextures.find(Texture) != m_SelectedTextures.end();
+		if (ImGui::Selectable(label.c_str(), &isSelected))
+		{
+			m_SelectedTextures.insert(Texture);
+
+			// Clear if you've deselected a Texture
+			if (!isSelected)
+				toDelete.insert(Texture);
+		}
+
+		index++;
+	}
+
+	for (auto selectedTexture : m_SelectedTextures)
+	{
+		std::string name = "Name: " + selectedTexture->GetName();
+
+		bool open = true;
+		ImGui::Begin(name.c_str(), &open);
+		ImGui::Text("%s", name.c_str());
+		ImGui::Text("Width: %u Bytes", selectedTexture->GetWidth());
+		ImGui::Text("Height: %u Bytes", selectedTexture->GetHeight());
+		ImGui::Text("Aligned Width: %u Bytes", selectedTexture->GetAlignedWidth());
+		ImGui::Text("Number of Channels: %u", selectedTexture->GetNumChannels());
+		ImGui::Text("Bytes per Channel: %u Bytes", selectedTexture->GetBytesPerChannel());
+		ImGui::Text("Size: %u Bytes",
+					selectedTexture->GetAlignedWidth() * selectedTexture->GetHeight() *
+						selectedTexture->GetBytesPerChannel() * selectedTexture->GetNumChannels());
+
+		// Display each flag if it is set
+		TextureFlags flags = selectedTexture->GetFlags();
+
+		if (flags == TextureFlags::NONE)
+		{
+			ImGui::Text("Flags: NONE");
+		}
+		else
+		{
+			ImGui::Text("Flags:");
+			if ((flags & TextureFlags::MIPMAP_GENERATE) != TextureFlags::NONE)
+				ImGui::BulletText("MIPMAP_GENERATE");
+			if ((flags & TextureFlags::ALLOW_UA) != TextureFlags::NONE)
+				ImGui::BulletText("ALLOW_UA");
+			if ((flags & TextureFlags::SCREENSIZE) != TextureFlags::NONE)
+				ImGui::BulletText("SCREENSIZE");
+		}
+
+		if (!open)
+			toDelete.insert(selectedTexture);
+
+		ImGui::End();
+	}
+
+	// Cleanup
+	for (const auto& Texture : toDelete)
+	{
+		m_SelectedTextures.erase(Texture);
+	}
+
+	ImGui::End();
+}
+
+// Utility function to check if a flag is set
+bool IsFlagSetA(int flags, int flag)
+{
+	return (flags & flag) == flag;
+}
+
+// Function to render the multi-select combo box
+void RenderMultiSelectComboA(const char* label, int& selectedFlags, const std::vector<std::string>& items)
+{
+	if (ImGui::BeginCombo(label, "Select..."))
+	{
+		for (int i = 0; i < items.size(); ++i)
+		{
+			bool isSelected = IsFlagSetA(selectedFlags, 1 << i);
+			if (ImGui::Checkbox(items[i].c_str(), &isSelected))
+			{
+				if (isSelected)
+					selectedFlags |= (1 << i); // Set the flag
+				else
+					selectedFlags &= ~(1 << i); // Clear the flag
+			}
+		}
+		ImGui::EndCombo();
+	}
+}

--- a/Engine/Source/Tools/ToolManager.cpp
+++ b/Engine/Source/Tools/ToolManager.cpp
@@ -21,6 +21,8 @@
 
 #include <sstream>
 
+#include "Tools/BufferVisualizer.h"
+
 using namespace Ball;
 
 #define REGISTER_TOOL(TYPE) RegisterTool<TYPE>(#TYPE)
@@ -43,6 +45,7 @@ void ToolManager::Init()
 	REGISTER_TOOL(GpuMarkerVisualizer);
 	REGISTER_TOOL(AudioParameter);
 	REGISTER_TOOL(InputViewTool);
+	REGISTER_TOOL(BufferVisualizer);
 
 	std::string source = Ball::LaunchParameters::GetString("OpenTools", "");
 	if (!source.empty())
@@ -66,6 +69,36 @@ void Ball::ToolManager::Shutdown()
 	}
 #endif // !NO_IMGUI
 }
+
+void ToolManager::CreateToolMenu(const char* menuName, ToolCatagory category) const
+{
+	if (ImGui::BeginMenu(menuName))
+	{
+		for (size_t i = 0; i < m_Tools.size(); i++)
+		{
+			ToolBase* tool = m_Tools[i];
+			if (tool->GetToolCatagory() == category)
+			{
+				if (ImGui::MenuItem(tool->GetName().c_str()))
+				{
+					if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
+						tool->ToggleOpen();
+					else
+						tool->Event();
+				}
+			}
+		}
+		ImGui::EndMenu();
+	}
+}
+
+// Use an array of menu names and categories to loop through and create each menu
+std::vector<std::pair<const char*, ToolCatagory>> m_MenuItems = {
+	{"Engine", ToolCatagory::ENGINE},
+	{"Graphics", ToolCatagory::GRAPHICS},
+	{"Resources", ToolCatagory::RESOURCES},
+	{"Audio", ToolCatagory::AUDIO},
+};
 
 void ToolManager::OnImgui()
 {
@@ -97,164 +130,9 @@ void ToolManager::OnImgui()
 	{
 		ImGui::BeginMainMenuBar();
 
-		// Menu tools
-		if (ImGui::BeginMenu("Menu"))
+		for (const auto& menu : m_MenuItems)
 		{
-			// Add item for showing imgui demo window
-			if (ImGui::MenuItem("ImGui demo window"))
-			{
-				m_ShowDemoWindow = !m_ShowDemoWindow;
-			}
-
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::MENU)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
-							tool->ToggleOpen();
-						else
-							tool->Event();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		// Engine tools
-		if (ImGui::BeginMenu("Engine"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::ENGINE)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
-							tool->ToggleOpen();
-						else
-							tool->Event();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		// Graphic tools
-		if (ImGui::BeginMenu("Graphics"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::GRAPHICS)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
-							tool->ToggleOpen();
-						else
-							tool->Event();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		// Mod.io tools
-		if (ImGui::BeginMenu("Mod.io"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::MODIO)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						tool->ToggleOpen();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		if (ImGui::BeginMenu("Physics"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::PHYSICS)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
-							tool->ToggleOpen();
-						else
-							tool->Event();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		// Mod.io tools
-		if (ImGui::BeginMenu("Audio"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::AUDIO)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						tool->ToggleOpen();
-					}
-				}
-			}
-			ImGui::EndMenu();
-		}
-
-		// Other tools
-		if (ImGui::BeginMenu("Other"))
-		{
-			// Loop over all tools and if it has the correct catagory show as item
-			// Looping over all the tools for each catagory is not the best but I couldn't figure out how to add to an
-			// menu i've already begin and ended in imgui
-			for (size_t i = 0; i < m_Tools.size(); i++)
-			{
-				ToolBase* tool = m_Tools[i];
-				if (tool->GetToolCatagory() == ToolCatagory::OTHER)
-				{
-					if (ImGui::MenuItem(tool->GetName().c_str()))
-					{
-						if (tool->GetInterfaceType() == ToolInterfaceType::WINDOW)
-							tool->ToggleOpen();
-						else
-							tool->Event();
-					}
-				}
-			}
-			ImGui::EndMenu();
+			CreateToolMenu(menu.first, menu.second);
 		}
 
 		ImGui::Separator();

--- a/Engine/Source/Tools/ToolManager.cpp
+++ b/Engine/Source/Tools/ToolManager.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include "Tools/BufferVisualizer.h"
+#include "Tools/TextureVisualizer.h"
 
 using namespace Ball;
 
@@ -46,6 +47,7 @@ void ToolManager::Init()
 	REGISTER_TOOL(AudioParameter);
 	REGISTER_TOOL(InputViewTool);
 	REGISTER_TOOL(BufferVisualizer);
+	REGISTER_TOOL(TextureVisualizer);
 
 	std::string source = Ball::LaunchParameters::GetString("OpenTools", "");
 	if (!source.empty())

--- a/Platforms/Windows/Source/BEAR/Texture.cpp
+++ b/Platforms/Windows/Source/BEAR/Texture.cpp
@@ -26,29 +26,6 @@ namespace Ball
 
 	Texture::Texture(const void* data, TextureSpec spec, const std::string& name) : m_Spec(spec), m_Name(name)
 	{
-		LoadTextureData(data, name);
-	}
-
-	Texture::Texture(const std::string& path, TextureSpec spec, const std::string& name) : m_Spec(spec), m_Name(name)
-	{
-		ASSERT_MSG(LOG_GRAPHICS, FileIO::Exist(FileIO::Engine, path), "Texture path doesn't exist: '%s'", path.c_str());
-		std::string texturepath = FileIO::GetPath(FileIO::Engine, path);
-
-		int width, height, channels;
-		auto* data = stbi_loadf(texturepath.c_str(), &width, &height, &channels, 4);
-
-		m_Spec.m_Width = width;
-		m_Spec.m_Height = height;
-
-		if (!data)
-			ASSERT_MSG(LOG_GRAPHICS, false, "stbi_load() failed in Texture constructor for %s", path.c_str());
-
-		LoadTextureData(data, name);
-		stbi_image_free(data);
-	}
-
-	void Texture::LoadTextureData(const void* data, const std::string& name)
-	{
 		DXGI_FORMAT createFormat = GetDXFormat(m_Spec.m_Format);
 		m_BytesPerChannel = GetBytesPerChannelFromFormat(m_Spec.m_Format);
 		m_Channels = GetNumChannelsFromFormat(m_Spec.m_Format);


### PR DESCRIPTION
# Changes
- Made GPU resource constructers private. Now they're managed through managers. I don't want to have dangling resources and be able to easily inspect any GPU Resources

- Added a very basic Textures inspector
- Added a very basic Buffer inspector 

- Cleaned up some code repetition in Tools
- Cleaned up the constructors the Texture wrapper. Now the manager is responsible for stb_image filepath loading. This makes more sense to me 

Etc: 
- Fixed small controller rumble warning
