### PR TITLE
🌨️ Upload Resources Optimization

### DIFF
--- a/Engine/Headers/Rendering/BEAR/Buffer.h
+++ b/Engine/Headers/Rendering/BEAR/Buffer.h
@@ -48,11 +48,11 @@ namespace Ball
 		// Use BufferManager for BufferCreation and deletion
 		friend BufferManager;
 		Buffer() = delete;
-
 		Buffer(const void* data, const uint32_t stride, const uint32_t count, BufferFlags flags = BufferFlags::NONE,
 			   const std::string& name = "default_name");
-
 		~Buffer();
+
+		void CleanupHelperResources();
 
 		GPUBufferHandle m_BufferHandle;
 		std::string m_Name = "DEFAULT_NAME_FOR_BUFFER";

--- a/Engine/Headers/Rendering/BEAR/Texture.h
+++ b/Engine/Headers/Rendering/BEAR/Texture.h
@@ -108,6 +108,8 @@ namespace Ball
 		Texture(const void* data, TextureSpec spec, const std::string& name = "default_name");
 		~Texture();
 
+		void CleanupHelperResources();
+
 		uint32_t GetAlignedSize() const
 		{
 			const uint32_t rowPitch = m_Spec.m_Width * m_Channels * m_BytesPerChannel;

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -1,13 +1,12 @@
 #pragma once
-#include <memory>
-#include <set>
 
 #include "BEAR/Buffer.h"
 
 namespace Ball
 {
+	class CommandList;
 	class BufferVisualizer;
-}
+} // namespace Ball
 
 namespace Ball
 {
@@ -22,10 +21,15 @@ namespace Ball
 
 		static size_t GetCount() { return m_BufferCount; }
 
+		// For Cleaning GPU Upload Buffers once they've completed their job
+		static void CleanupHelperResources();
+
 	private:
 		BufferManager() = delete;
 		BufferManager(const BufferManager&) = delete;
 		BufferManager& operator=(const BufferManager&) = delete;
+
+		;
 
 		friend BufferVisualizer; // Uses this data to display info about Buffers
 		static inline std::list<Buffer*> m_Buffers;

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -5,6 +5,8 @@
 namespace Ball
 {
 	class BufferVisualizer;
+	class BackEndRenderer;
+
 } // namespace Ball
 
 namespace Ball
@@ -20,13 +22,14 @@ namespace Ball
 
 		static size_t GetCount() { return m_BufferCount; }
 
-		// For Cleaning GPU Upload Buffers once they've completed their job
-		static void CleanupHelperResources();
-
 	private:
 		BufferManager() = delete;
 		BufferManager(const BufferManager&) = delete;
 		BufferManager& operator=(const BufferManager&) = delete;
+
+		// For Cleaning GPU Upload Buffers once they've completed their job
+		friend BackEndRenderer; // DirectX Specific (only this API is used rn)
+		static void CleanupHelperResources();
 
 		friend BufferVisualizer; // Uses this data to display info about Buffers
 		static inline std::list<Buffer*> m_Buffers;

--- a/Engine/Headers/Rendering/BufferManager.h
+++ b/Engine/Headers/Rendering/BufferManager.h
@@ -4,7 +4,6 @@
 
 namespace Ball
 {
-	class CommandList;
 	class BufferVisualizer;
 } // namespace Ball
 
@@ -28,8 +27,6 @@ namespace Ball
 		BufferManager() = delete;
 		BufferManager(const BufferManager&) = delete;
 		BufferManager& operator=(const BufferManager&) = delete;
-
-		;
 
 		friend BufferVisualizer; // Uses this data to display info about Buffers
 		static inline std::list<Buffer*> m_Buffers;

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -24,6 +24,9 @@ namespace Ball
 		// Function to get TextureType as string
 		static std::string GetTypeAsString(const TextureType type);
 
+		// HACK : Move this out of here
+		static void CleanupHelperResources();
+
 	private:
 		TextureManager() = delete;
 		TextureManager(const TextureManager&) = delete;

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -5,6 +5,11 @@
 namespace Ball
 {
 	class TextureVisualizer;
+	class BackEndRenderer;
+} // namespace Ball
+
+namespace Ball
+{
 	class TextureManager
 	{
 	public:
@@ -24,13 +29,14 @@ namespace Ball
 		// Function to get TextureType as string
 		static std::string GetTypeAsString(const TextureType type);
 
-		// For Cleaning GPU Upload Buffers once they've completed their job
-		static void CleanupHelperResources();
-
 	private:
 		TextureManager() = delete;
 		TextureManager(const TextureManager&) = delete;
 		TextureManager& operator=(const TextureManager&) = delete;
+
+		// For Cleaning GPU Upload Buffers once they've completed their job
+		friend BackEndRenderer; // DirectX Specific (only this API is used rn)
+		static void CleanupHelperResources();
 
 		friend TextureVisualizer; // Uses this data to display info about Textures
 		static inline std::list<Texture*> m_Textures;

--- a/Engine/Headers/Rendering/TextureManager.h
+++ b/Engine/Headers/Rendering/TextureManager.h
@@ -24,7 +24,7 @@ namespace Ball
 		// Function to get TextureType as string
 		static std::string GetTypeAsString(const TextureType type);
 
-		// HACK : Move this out of here
+		// For Cleaning GPU Upload Buffers once they've completed their job
 		static void CleanupHelperResources();
 
 	private:

--- a/Engine/Source/Levels/Level.cpp
+++ b/Engine/Source/Levels/Level.cpp
@@ -31,7 +31,8 @@ namespace Ball
 		const std::string randomFile = hdrFiles[distr(gen)];
 		const std::string finalfile = path + randomFile;
 
-		Ball::GetEngine().GetRenderer().LoadSkybox(finalfile);
+		// DON'T COMMIT THIS (only for testing)
+		// Ball::GetEngine().GetRenderer().LoadSkybox(finalfile);
 	}
 
 	Level::~Level()

--- a/Engine/Source/Levels/Level.cpp
+++ b/Engine/Source/Levels/Level.cpp
@@ -31,8 +31,7 @@ namespace Ball
 		const std::string randomFile = hdrFiles[distr(gen)];
 		const std::string finalfile = path + randomFile;
 
-		// DON'T COMMIT THIS (only for testing)
-		// Ball::GetEngine().GetRenderer().LoadSkybox(finalfile);
+		Ball::GetEngine().GetRenderer().LoadSkybox(finalfile);
 	}
 
 	Level::~Level()

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -27,4 +27,15 @@ namespace Ball
 
 		m_Buffers.clear();
 	}
+
+	void BufferManager::CleanupHelperResources()
+	{
+		// HACK : DirectX 12 specific
+		for (const auto& buf : m_Buffers)
+		{
+			if (buf->GetGPUHandleRef().m_Uploader.Get() != nullptr)
+				buf->GetGPUHandleRef().m_Uploader.Reset();
+		}
+	}
+
 } // namespace Ball

--- a/Engine/Source/Rendering/BufferManager.cpp
+++ b/Engine/Source/Rendering/BufferManager.cpp
@@ -30,12 +30,8 @@ namespace Ball
 
 	void BufferManager::CleanupHelperResources()
 	{
-		// HACK : DirectX 12 specific
 		for (const auto& buf : m_Buffers)
-		{
-			if (buf->GetGPUHandleRef().m_Uploader.Get() != nullptr)
-				buf->GetGPUHandleRef().m_Uploader.Reset();
-		}
+			buf->CleanupHelperResources();
 	}
 
 } // namespace Ball

--- a/Engine/Source/Rendering/Renderer.cpp
+++ b/Engine/Source/Rendering/Renderer.cpp
@@ -369,7 +369,9 @@ namespace Ball
 		// Wait for Previous frame to Complete
 		m_BackEndAPI->WaitForCmdQueueExecute();
 		m_BackEndAPI->BeginFrame();
+
 		BufferManager::CleanupHelperResources();
+		TextureManager::CleanupHelperResources();
 	}
 
 	void RenderAPI::Render()
@@ -982,7 +984,14 @@ namespace Ball
 		// Make sure we have a skybox texture loaded if we have none done so before
 		if (m_SkyTexture == nullptr)
 		{
-			LoadSkybox(LaunchParameters::GetString("Skybox", "Images/HDRIs/space4.hdr"));
+			// Kinda dumb but should work...
+			LoadSkybox(LaunchParameters::GetString("Skybox", "Images/HDRIs/green_aurora.hdr"));
+			TextureSpec skyboxSpec;
+			skyboxSpec.m_Format = TextureFormat::R32_G32_B32_A32_FLOAT;
+			skyboxSpec.m_Type = TextureType::R_TEXTURE;
+			skyboxSpec.m_Flags = TextureFlags::NONE;
+
+			m_SkyTexture = TextureManager::CreateFromFilepath(m_UpdateNewSkyboxPath, skyboxSpec, "Skybox");
 		}
 	}
 

--- a/Engine/Source/Rendering/Renderer.cpp
+++ b/Engine/Source/Rendering/Renderer.cpp
@@ -369,6 +369,7 @@ namespace Ball
 		// Wait for Previous frame to Complete
 		m_BackEndAPI->WaitForCmdQueueExecute();
 		m_BackEndAPI->BeginFrame();
+		BufferManager::CleanupHelperResources();
 	}
 
 	void RenderAPI::Render()

--- a/Engine/Source/Rendering/Renderer.cpp
+++ b/Engine/Source/Rendering/Renderer.cpp
@@ -369,9 +369,6 @@ namespace Ball
 		// Wait for Previous frame to Complete
 		m_BackEndAPI->WaitForCmdQueueExecute();
 		m_BackEndAPI->BeginFrame();
-
-		BufferManager::CleanupHelperResources();
-		TextureManager::CleanupHelperResources();
 	}
 
 	void RenderAPI::Render()
@@ -1031,7 +1028,7 @@ namespace Ball
 		TonemapParameters tm;
 
 		tm.m_TonemapMethod = TM_LINEAR;
-		tm.m_Exposure = 0.2f;
+		tm.m_Exposure = 0.8f;
 		tm.m_Gamma = 1.9f;
 		tm.m_MaxLuminance = 1.0f;
 		tm.m_ReinhardConstant = 1.0f;

--- a/Engine/Source/Rendering/TextureManager.cpp
+++ b/Engine/Source/Rendering/TextureManager.cpp
@@ -92,3 +92,13 @@ std::string TextureManager::GetTypeAsString(const TextureType type)
 		return "Unknown Type";
 	}
 }
+
+void TextureManager::CleanupHelperResources()
+{
+	// HACK : DirectX 12 specific
+	for (const auto& buf : m_Textures)
+	{
+		if (buf->GetGPUHandleRef().m_Uploader.Get() != nullptr)
+			buf->GetGPUHandleRef().m_Uploader.Reset();
+	}
+}

--- a/Engine/Source/Rendering/TextureManager.cpp
+++ b/Engine/Source/Rendering/TextureManager.cpp
@@ -95,7 +95,6 @@ std::string TextureManager::GetTypeAsString(const TextureType type)
 
 void TextureManager::CleanupHelperResources()
 {
-	// HACK : DirectX 12 specific
 	for (const auto& tex : m_Textures)
 		tex->CleanupHelperResources();
 }

--- a/Engine/Source/Rendering/TextureManager.cpp
+++ b/Engine/Source/Rendering/TextureManager.cpp
@@ -96,9 +96,6 @@ std::string TextureManager::GetTypeAsString(const TextureType type)
 void TextureManager::CleanupHelperResources()
 {
 	// HACK : DirectX 12 specific
-	for (const auto& buf : m_Textures)
-	{
-		if (buf->GetGPUHandleRef().m_Uploader.Get() != nullptr)
-			buf->GetGPUHandleRef().m_Uploader.Reset();
-	}
+	for (const auto& tex : m_Textures)
+		tex->CleanupHelperResources();
 }

--- a/Platforms/Windows/Source/BEAR/Buffer.cpp
+++ b/Platforms/Windows/Source/BEAR/Buffer.cpp
@@ -48,6 +48,7 @@ namespace Ball
 			// Fill in data
 			if ((m_Flags & BufferFlags::DEFAULT_HEAP) != BufferFlags::NONE)
 			{
+				// Note: this might be unnecessary
 				if (m_BufferHandle.m_Uploader.Get() != nullptr)
 					m_BufferHandle.m_Uploader.Get()->Release();
 

--- a/Platforms/Windows/Source/BEAR/Buffer.cpp
+++ b/Platforms/Windows/Source/BEAR/Buffer.cpp
@@ -48,12 +48,10 @@ namespace Ball
 			// Fill in data
 			if ((m_Flags & BufferFlags::DEFAULT_HEAP) != BufferFlags::NONE)
 			{
-				// Note: this might be unnecessary
-				if (m_BufferHandle.m_Uploader.Get() != nullptr)
-					m_BufferHandle.m_Uploader.Get()->Release();
-
 				// For default heap we need to use a staging resource as we can't write straight to it
 				CD3DX12_RANGE readRange(0, 0);
+				ASSERT_MSG(
+					LOG_GRAPHICS, m_BufferHandle.m_Uploader == nullptr, "Buffer must be null to create a new one");
 				m_BufferHandle.m_Uploader = Helpers::CreateBuffer(
 					bufferSize, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_GENERIC_READ, Helpers::kUploadHeapProps);
 
@@ -104,9 +102,6 @@ namespace Ball
 	{
 		m_BufferHandle.m_Buffer.Reset();
 
-		if (m_BufferHandle.m_Uploader.Get() != nullptr)
-			m_BufferHandle.m_Uploader.Reset();
-
 		m_Count = newCount;
 		uint32_t bufferSize = m_Stride * m_Count;
 
@@ -132,6 +127,7 @@ namespace Ball
 
 		if ((m_Flags & BufferFlags::DEFAULT_HEAP) != BufferFlags::NONE)
 		{
+			ASSERT_MSG(LOG_GRAPHICS, m_BufferHandle.m_Uploader == nullptr, "Buffer must be null to create a new one");
 			m_BufferHandle.m_Uploader = Helpers::CreateBuffer(
 				bufferSize, D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_GENERIC_READ, Helpers::kUploadHeapProps);
 		}
@@ -144,8 +140,15 @@ namespace Ball
 			GetEngine().GetRenderer().RemoveScreensize(this);
 		}
 
+		CleanupHelperResources();
 		m_BufferHandle.m_Buffer.ReleaseAndGetAddressOf();
-		m_BufferHandle.m_Uploader.ReleaseAndGetAddressOf();
 	}
 
+	void Buffer::CleanupHelperResources()
+	{
+		// Only this should be responsible for cleaning up the uploader
+		// and (eventually) readback buffers.
+		if (m_BufferHandle.m_Uploader.Get() != nullptr)
+			m_BufferHandle.m_Uploader.Reset();
+	}
 } // namespace Ball

--- a/Platforms/Windows/Source/BackEndRenderer.cpp
+++ b/Platforms/Windows/Source/BackEndRenderer.cpp
@@ -25,6 +25,9 @@
 #include <ImGui/imgui_impl_dx12.h>
 #include <stb/stb_image.h>
 
+#include "Rendering/BufferManager.h"
+#include "Rendering/TextureManager.h"
+
 #pragma clang diagnostic pop
 
 // Load DX12 Agility. This is required for devices that don't support Shader model 6.6 and other DX12 Ultimate features
@@ -280,6 +283,9 @@ namespace Ball
 			GlobalDX12::g_FrameIndex * GlobalDX12::g_RTVDescSize;
 
 		GlobalDX12::g_DirectCommandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+
+		BufferManager::CleanupHelperResources();
+		TextureManager::CleanupHelperResources();
 	}
 
 	void BackEndRenderer::PresentFrame()


### PR DESCRIPTION
Before we used to keep them around for the whole lifetime of the buffer. Now we deallocate them when they're not in use at the start of the next frame.


Other fixes:
- Fixed Fullscreen not being displayed correctly on the first frame.
- Fixed WindowWidth and WindowHeight being set to size of the window, not the renderable area.
- Fixed Skybox's not loading correctly whenever no path is specified
- Added a few asserts to make sure upload buffers are used when valid